### PR TITLE
Added plassembler to conda env

### DIFF
--- a/scripts/environment.yml
+++ b/scripts/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - necat>=0.0.1_update20200803  # https://github.com/xiaochuanle/NECAT
   - nextdenovo>=2.5.2            # https://github.com/Nextomics/NextDenovo
   - nextpolish>=1.4.1            # https://github.com/Nextomics/NextPolish
+  - plassembler>=1.6.2           # https://github.com/gbouras13/plassembler
   - racon>=1.5.0                 # https://github.com/lbcb-sci/racon
   - raven-assembler>=1.8.3       # https://github.com/lbcb-sci/raven
   - seqtk>=1.4                   # https://github.com/lh3/seqtk


### PR DESCRIPTION
I updated the canu dependency for plassembler in bioconda, so it's now compatible in this environment.