### PR TITLE
Added pacbio-hifi option to assembler scripts

### DIFF
--- a/scripts/canu.sh
+++ b/scripts/canu.sh
@@ -29,6 +29,7 @@ reads=$1        # input reads FASTQ
 assembly=$2     # output assembly prefix (not including file extension)
 threads=$3      # thread count
 genome_size=$4  # estimated genome size
+read_type=$5	# ont or pb read type
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" || -z "$genome_size" ]]; then
@@ -63,8 +64,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Select read type preset
+if [[ "$read_type"  == "ont" ]]; then
+    read_type_preset="-nanopore"
+elif [[ "$read_type" == "pb" ]]; then
+    read_type_preset="-pacbio-hifi"
+else
+    >&2 echo "Error: $read_type is not supported"
+    exit 1
+fi
+
 # Run Canu.
-canu -p canu -d "$temp_dir" -fast genomeSize="$genome_size" useGrid=false maxThreads="$threads" -nanopore "$reads"
+canu -p canu -d "$temp_dir" -fast genomeSize="$genome_size" useGrid=false maxThreads="$threads" "$read_type_preset" "$reads"
 
 # Check if Canu ran successfully.
 if [[ ! -s "$temp_dir"/canu.contigs.fasta ]]; then

--- a/scripts/flye.sh
+++ b/scripts/flye.sh
@@ -27,6 +27,7 @@ set -e
 reads=$1        # input reads FASTQ
 assembly=$2     # output assembly prefix (not including file extension)
 threads=$3      # thread count
+read_type=$5    # ont or pb read type
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" ]]; then
@@ -61,8 +62,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Select read type preset
+if [[ "$read_type"  == "ont" ]]; then
+    read_type_preset="--nano-hq"
+elif [[ "$read_type" == "pb" ]]; then
+    read_type_preset="--pacbio-hifi"
+else
+    >&2 echo "Error: $read_type is not supported"
+    exit 1
+fi
+
 # Run Flye.
-flye --nano-hq "$reads" --threads "$threads" --out-dir "$temp_dir"
+flye "$read_type_preset" "$reads" --threads "$threads" --out-dir "$temp_dir"
 
 # Check if Flye ran successfully.
 if [[ ! -s "$temp_dir"/assembly.fasta ]]; then

--- a/scripts/miniasm.sh
+++ b/scripts/miniasm.sh
@@ -31,6 +31,7 @@ set -e
 reads=$1        # input reads FASTQ
 assembly=$2     # output assembly prefix (not including file extension)
 threads=$3      # thread count
+read_type=$5    # ont or pb read type
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" ]]; then
@@ -65,8 +66,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Select read type preset
+if [[ "$read_type"  == "ont" ]]; then
+    read_type_preset="ava-ont"
+elif [[ "$read_type" == "pb" ]]; then
+    read_type_preset="ava-pb"
+else
+    >&2 echo "Error: $read_type is not supported"
+    exit 1
+fi
+
 # Find read overlaps with minimap2.
-minimap2 -x ava-ont -t "$threads" "$reads" "$reads" > "$temp_dir"/overlap.paf
+minimap2 -x "$read_type_preset" -t "$threads" "$reads" "$reads" > "$temp_dir"/overlap.paf
 
 # Run miniasm to make an unpolished assembly.
 miniasm -f "$reads" "$temp_dir"/overlap.paf > "$temp_dir"/unpolished.gfa

--- a/scripts/miniasm.sh
+++ b/scripts/miniasm.sh
@@ -99,7 +99,7 @@ else
 fi
 
 # Polish the assembly with Minipolish, outputting the result to stdout.
-minipolish --threads "$threads" "$read_type_polishing_preset"  "$reads" "$temp_dir"/unpolished.gfa > "$assembly".gfa
+minipolish $read_type_polishing_preset --threads "$threads" "$reads" "$temp_dir"/unpolished.gfa > "$assembly".gfa
 
 # Check if Minipolish ran successfully.
 if [[ ! -s "$assembly".gfa ]]; then

--- a/scripts/miniasm.sh
+++ b/scripts/miniasm.sh
@@ -88,8 +88,18 @@ if [[ ! -s "$temp_dir"/unpolished.gfa ]]; then
     exit 1
 fi
 
+# Select read type preset
+if [[ "$read_type"  == "ont" ]]; then
+    read_type_polishing_preset=""
+elif [[ "$read_type" == "pb" ]]; then
+    read_type_polishing_preset="--pacbio"
+else
+    >&2 echo "Error: $read_type is not supported"
+    exit 1
+fi
+
 # Polish the assembly with Minipolish, outputting the result to stdout.
-minipolish --threads "$threads" "$reads" "$temp_dir"/unpolished.gfa > "$assembly".gfa
+minipolish --threads "$threads" "$read_type_polishing_preset"  "$reads" "$temp_dir"/unpolished.gfa > "$assembly".gfa
 
 # Check if Minipolish ran successfully.
 if [[ ! -s "$assembly".gfa ]]; then

--- a/scripts/nextdenovo.sh
+++ b/scripts/nextdenovo.sh
@@ -119,9 +119,17 @@ fi
 
 # Select read type preset
 if [[ "$read_type"  == "ont" ]]; then
-    read_type_mapping_preset="map-ont"
+    read_type_polishing_preset="[lgs option]
+    lgs_fofn = lgs.fofn
+    lgs_options = -min_read_len 1k -max_depth 100
+    lgs_minimap2_options = -x map-ont -t $threads"
+    reads_fofn="lgs.fofn"
 elif [[ "$read_type" == "pb" ]]; then
-    read_type_mapping_preset="map-hifi"
+    read_type_polishing_preset="[hifi_option]
+    hifi_fofn = ./hifi.fofn
+    hifi_options = -min_read_len 1k -max_depth 100
+    hifi_minimap2_options = -x map-pb -t $threads"
+    reads_fofn="hifi.fofn"
 else
     >&2 echo "Error: $read_type is not supported"
     exit 1
@@ -143,12 +151,9 @@ genome_size = auto
 workdir = nextpolish
 polish_options = -p $threads
 
-[lgs_option]
-lgs_fofn = lgs.fofn
-lgs_options = -min_read_len 1k -max_depth 100
-lgs_minimap2_options = -x $read_type_mapping_preset -t $threads
+$read_type_polishing_preset
 EOF
-echo "$reads_abs" > lgs.fofn
+echo "$reads_abs" > "$reads_fofn"
 
 # Run NextPolish.
 nextPolish nextpolish_run.cfg

--- a/scripts/raven.sh
+++ b/scripts/raven.sh
@@ -27,6 +27,7 @@ set -e
 reads=$1        # input reads FASTQ
 assembly=$2     # output assembly prefix (not including file extension)
 threads=$3      # thread count
+read_type=$5    # ont or pb read type
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" ]]; then
@@ -61,8 +62,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Select read type preset
+if [[ "$read_type"  == "ont" ]]; then
+    read_type_preset=""
+elif [[ "$read_type" == "pb" ]]; then
+    read_type_preset="-k 29 -w 9"
+else
+    >&2 echo "Error: $read_type is not supported"
+    exit 1
+fi
+
 # Run Raven.
-raven --threads "$threads" --disable-checkpoints --graphical-fragment-assembly "$assembly".gfa "$reads" > "$assembly".fasta
+raven --threads "$threads" "$read_type_preset"  --disable-checkpoints --graphical-fragment-assembly "$assembly".gfa "$reads" > "$assembly".fasta
 
 # Check if Raven ran successfully.
 if [[ ! -s "$assembly".fasta ]]; then

--- a/scripts/raven.sh
+++ b/scripts/raven.sh
@@ -73,7 +73,7 @@ else
 fi
 
 # Run Raven.
-raven --threads "$threads" "$read_type_preset"  --disable-checkpoints --graphical-fragment-assembly "$assembly".gfa "$reads" > "$assembly".fasta
+raven --threads "$threads" $read_type_preset --disable-checkpoints --graphical-fragment-assembly "$assembly".gfa "$reads" > "$assembly".fasta
 
 # Check if Raven ran successfully.
 if [[ ! -s "$assembly".fasta ]]; then


### PR DESCRIPTION
I added an option ("ont" or "pb") to choose between ont and pacbio hifi data to the scripts of these assemblers:

Canu:
ont → -nanopore
pb → -pacbio-hifi

Flye:
ont → --nano-hq
pb → --pacbio-hifi

Miniasm + Minipolish:
ont → ava-ont preset for minimap2
pb → ava-pb preset for minimap2 and --pacbio flag for minipolish

NextDenovo:
ont → read_type = ont and  lgs_options for NextPolish
pb → read_type = hifi and hifi_options for NextPolish

Raven:
ont → default parameters
pb → adds -k 29 -w 9, as recommended for hifi reads (https://doi.org/10.1038/s43588-021-00073-4)