### PR TITLE
New Docker image bundling all assemblers

### DIFF
--- a/pipelines/Dockerfile_by_Thomas_Roder/Dockerfile
+++ b/pipelines/Dockerfile_by_Thomas_Roder/Dockerfile
@@ -1,0 +1,74 @@
+# Builder base
+FROM mambaorg/micromamba:latest as builder
+USER root
+COPY --chmod=755 install_tools.sh /usr/local/bin/
+USER $MAMBA_USER
+
+# Create separate builders to facilitate developing this Docker image
+# Should run in parallel with modern BuildKit.
+# Enable multiple processes with Podman: podman build --tag autocycler --jobs 0
+FROM builder as builder_flye
+RUN install_tools.sh flye
+FROM builder as builder_canu
+RUN install_tools.sh canu bioconda::canu
+FROM builder as builder_metamdbg
+RUN install_tools.sh metamdbg
+FROM builder as builder_necat
+RUN install_tools.sh necat
+FROM builder as builder_minipolish
+RUN install_tools.sh minipolish miniasm bioconda::minipolish racon any2fasta
+FROM builder as builder_verkko
+RUN install_tools.sh Verkko
+FROM builder as builder_nextdenovo
+RUN install_tools.sh nextdenovo nextdenovo nextpolish
+FROM builder as builder_raven
+RUN install_tools.sh raven raven-assembler
+FROM builder as builder_wtdbg
+RUN install_tools.sh wtdbg
+FROM builder as builder_plassembler
+RUN install_tools.sh plassembler
+
+# Actual Autocycler build starts here
+FROM mambaorg/micromamba:latest
+
+# Install dependencies (libgomp1 for lja)
+USER root
+RUN apt-get update && \
+    apt-get install -y vim curl libgomp1 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Switch back to default user
+USER $MAMBA_USER
+
+# Create a default autocycler env
+RUN micromamba create -y -n autocycler python && micromamba clean --all --yes
+ENV PATH="/opt/conda/envs/autocycler/bin:$PATH"
+
+# Download and install Autocycler (binary and scripts) from the latest release.
+RUN curl -L -o autocycler.tar.gz $(curl -s https://api.github.com/repos/rrwick/Autocycler/releases/latest | grep "browser_download_url.*linux-x86_64-musl.*tar.gz" | cut -d '"' -f 4) && \
+    curl -L -o autocycler_scripts.tar.gz $(curl -s https://api.github.com/repos/rrwick/Autocycler/releases/latest | grep "browser_download_url.*autocycler-helper-scripts.*tar.gz" | cut -d '"' -f 4) && \
+    tar -xzf autocycler.tar.gz && \
+    tar -xzf autocycler_scripts.tar.gz && \
+    mv autocycler *.sh *.py /opt/conda/envs/autocycler/bin/ && \
+    rm environment.yml autocycler.tar.gz autocycler_scripts.tar.gz
+
+# Copy certain tools from public containers
+COPY --from=docker.io/staphb/seqtk /usr/local/bin/seqtk /usr/local/bin/seqtk
+COPY --from=docker.io/staphb/minimap2 /usr/local/bin/minimap2 /usr/local/bin/minimap2
+COPY --from=docker.io/troder/lja /opt/LJA/bin/lja /usr/local/bin/lja
+
+# Copy the installed tools from each builder stage
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_raven /opt/conda/envs/raven /opt/conda/envs/raven
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_flye /opt/conda/envs/flye /opt/conda/envs/flye
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_canu /opt/conda/envs/canu /opt/conda/envs/canu
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_metamdbg /opt/conda/envs/metamdbg /opt/conda/envs/metamdbg
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_necat /opt/conda/envs/necat /opt/conda/envs/necat
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_minipolish /opt/conda/envs/minipolish /opt/conda/envs/minipolish
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_verkko /opt/conda/envs/Verkko /opt/conda/envs/Verkko
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_nextdenovo /opt/conda/envs/nextdenovo /opt/conda/envs/nextdenovo
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_wtdbg /opt/conda/envs/wtdbg /opt/conda/envs/wtdbg
+# pbassembler: huge install -.-
+COPY --chown=$MAMBA_USER_ID:$MAMBA_USER_GID --chmod=755 --from=builder_plassembler /opt/conda/envs/plassembler /opt/conda/envs/plassembler
+
+# Set default command to Autocycler help and show missing/installed tools.
+CMD ["/bin/sh", "-c", "autocycler --help"]

--- a/pipelines/Dockerfile_by_Thomas_Roder/README.md
+++ b/pipelines/Dockerfile_by_Thomas_Roder/README.md
@@ -1,0 +1,56 @@
+# **Advanced Autocycler Docker Image**
+
+## **Overview**
+
+An alternative Docker image for Autocycler.
+
+**Key differences:**
+
+* Assemblers installed into separate Micromamba environments
+* Successfully installs all targeted assemblers
+* Reduced Build Speed: Docker's multi-stage builds are parallelizable
+* Disadvantages: increased image size and Dockerfile complexity
+
+## **Building the Image**
+
+Ensure Dockerfile and `install_tools.sh` are in the same directory.
+
+```bash
+# Using Docker  
+docker build --tag autocycler .
+# Using Podman (with parallel jobs)  
+podman build --tag autocycler --jobs 0 .
+```
+
+## **Running the Container**
+
+```bash
+# Interactive Session
+docker run --rm -it autocycler bash
+# Mounting Data
+docker run --rm -it -v /path/to/your/data:/data autocycler bash
+```
+
+## **Installed Software & Environment Activation**
+
+Autocycler itself and its helper scripts are installed in the autocycler Conda environment, which is added to the system
+PATH. Thus, autocycler can be run directly.  
+The following table lists the installed assemblers/tools and the commands required to activate their respective
+environments if needed for manual use in an interactive session:
+
+| Assembler                                    | Activation Command              |
+|:---------------------------------------------|:--------------------------------|
+| Autocycler                                   | no activation needed            |
+| Flye                                         | micromamba activate flye        |
+| Canu                                         | micromamba activate canu        |
+| MetaMDBG                                     | micromamba activate metamdbg    |
+| NECAT                                        | micromamba activate necat       |
+| Minipolish (incl. Miniasm, Racon, Any2fasta) | micromamba activate minipolish  |
+| Verkko                                       | micromamba activate Verkko      |
+| NextDenovo (incl. NextPolish)                | micromamba activate nextdenovo  |
+| Raven                                        | micromamba activate raven       |
+| WTDBG2 (wtdbg)                               | micromamba activate wtdbg       |
+| Plassembler                                  | micromamba activate plassembler |
+| LJA                                          | no activation needed            |
+| Seqtk (not an assembler)                     | no activation needed            |
+| Minimap2 (not an assembler)                  | no activation needed            |

--- a/pipelines/Dockerfile_by_Thomas_Roder/install_tools.sh
+++ b/pipelines/Dockerfile_by_Thomas_Roder/install_tools.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+install_tool() {
+    set -e # Exit immediately if a command exits with a non-zero status.
+
+    if [ "$#" -lt 1 ]; then
+        echo "Error: Usage: $0 <env_name> [package1 package2 ...]" >&2
+        echo "Error: At least the environment name is required." >&2
+        return 1
+    fi
+
+    local env_name="$1"
+    shift
+
+    local primary_package_to_install
+    local additional_packages_to_install=()
+    local packages_for_echo_list=()
+
+    if [ "$#" -eq 0 ]; then
+        primary_package_to_install="$env_name"
+        packages_for_echo_list=("$env_name")
+    else
+        primary_package_to_install="$1"
+        packages_for_echo_list+=("$primary_package_to_install")
+        shift
+        additional_packages_to_install=("$@")
+
+        if [ "${#additional_packages_to_install[@]}" -gt 0 ]; then
+            packages_for_echo_list+=("${additional_packages_to_install[@]}")
+        fi
+    fi
+
+    echo ">>> Creating environment '$env_name' and installing: ${packages_for_echo_list[*]}"
+    micromamba create -y -n "$env_name" -c conda-forge -c bioconda "$primary_package_to_install" "${additional_packages_to_install[@]}"
+
+    echo ">>> Successfully created environment '$env_name' and installed ${packages_for_echo_list[*]}"
+    micromamba clean --all --yes
+}
+
+# Call the function with all script arguments
+install_tool "$@"


### PR DESCRIPTION
Hey Ryan,

This PR introduces a Docker image designed to bundle all assemblers.

**Approach:**

To manage dependencies effectively and avoid conflicts, each assembler is installed into its own micromamba environment within a separate builder stage. These isolated environments are then copied into the final image.

The LJA binary was simply copied from my container [troder/lja](https://hub.docker.com/r/troder/lja) because it is broken in conda

I had to adjust some of your `assembler.sh` scripts: if the relevant micromamba env exists, it is activated automatically.

**Advantages:**

*   **Avoids Dependency Conflicts:** Successfully installs all targeted assemblers
*   **Reduced Build Speed:** Docker's multi-stage builds are parallelizable.

**Disadvantages:**

*   **Image Size:** The final image is relatively large (8.38 GB)
*   **Dockerfile Complexity**

Let me know what you think and whether you would like any changes.