### PR TITLE
Support PacBio HiFi

### DIFF
--- a/scripts/lja.sh
+++ b/scripts/lja.sh
@@ -3,7 +3,8 @@
 # This script is a wrapper for running La Jolla Assembler in a single command.
 
 # Usage:
-#   lja.sh <read_fastq> <assembly_prefix> <threads>
+#   lja.sh <read_fastq> <assembly_prefix> <threads> [read_type]
+#   read_type is ignored, as LJA does not have read-specific options
 
 # Requirements:
 #   La Jolla Assembler: https://github.com/AntonBankevich/LJA
@@ -24,13 +25,15 @@
 set -e
 
 # Get arguments.
-reads=$1        # input reads FASTQ
-assembly=$2     # output assembly prefix (not including file extension)
-threads=$3      # thread count
+reads=$1            # input reads FASTQ
+assembly=$2         # output assembly prefix (not including file extension)
+threads=$3          # thread count
+read_type=${4:-ONT} # ignored, LJA does not have read-specific options
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" ]]; then
-    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads>"
+    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads> [read_type]"
+    >&2 echo "  read_type is ignored, as LJA does not have read-specific options."
     exit 1
 fi
 

--- a/scripts/necat.sh
+++ b/scripts/necat.sh
@@ -3,7 +3,8 @@
 # This script is a wrapper for running NECAT in a single command.
 
 # Usage:
-#   necat.sh <read_fastq> <assembly_prefix> <threads> <genome_size>
+#   necat.sh <read_fastq> <assembly_prefix> <threads> <genome_size> [read_type]
+#   read_type can be ONT (default). PB_HIFI is not supported by NECAT.
 
 # Requirements:
 #   NECAT: https://github.com/xiaochuanle/NECAT
@@ -24,16 +25,25 @@
 set -e
 
 # Get arguments.
-reads=$1        # input reads FASTQ
-assembly=$2     # output assembly prefix (not including file extension)
-threads=$3      # thread count
-genome_size=$4  # estimated genome size
+reads=$1            # input reads FASTQ
+assembly=$2         # output assembly prefix (not including file extension)
+threads=$3          # thread count
+genome_size=$4      # estimated genome size
+read_type=${5:-ONT} # ONT (default). PB_HIFI is not supported.
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" || -z "$genome_size" ]]; then
-    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads> <genome_size>"
+    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads> <genome_size> [read_type]"
+    >&2 echo "  read_type can be ONT (default). PB_HIFI is not supported by NECAT."
     exit 1
 fi
+
+# Check read_type and exit if PB_HIFI
+if [[ "$read_type" != "ONT" ]]; then
+    >&2 echo "Error: Invalid read_type: $read_type. Only 'ONT' is supported by NECAT."
+    exit 1
+fi
+
 assembly_abs=$(realpath "$assembly")
 
 # Check that the reads file exists.

--- a/scripts/nextdenovo.sh
+++ b/scripts/nextdenovo.sh
@@ -3,11 +3,13 @@
 # This script is a wrapper for running NextDenovo and NextPolish in a single command.
 
 # Usage:
-#   nextdenovo.sh <read_fastq> <assembly_prefix> <threads> <genome_size>
+#   nextdenovo.sh <read_fastq> <assembly_prefix> <threads> <genome_size> [read_type]
+#   read_type can be ONT (default). PB_HIFI/hifi support is planned.
 
 # Requirements:
 #   NextDenovo: https://github.com/Nextomics/NextDenovo
 #   NextPolish: https://github.com/Nextomics/NextPolish
+#   (NextPolish2 will be required for hifi reads in the future)
 
 # Copyright 2024 Ryan Wick (rrwick@gmail.com)
 # https://github.com/rrwick/Autocycler
@@ -25,16 +27,27 @@
 set -e
 
 # Get arguments.
-reads=$1        # input reads FASTQ
-assembly=$2     # output assembly prefix (not including file extension)
-threads=$3      # thread count
-genome_size=$4  # estimated genome size
+reads=$1            # input reads FASTQ
+assembly=$2         # output assembly prefix (not including file extension)
+threads=$3          # thread count
+genome_size=$4      # estimated genome size
+read_type=${5:-ONT} # ONT (default). hifi support is planned.
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" || -z "$genome_size" ]]; then
-    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads> <genome_size>"
+    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads> <genome_size> [read_type]"
+    >&2 echo "  read_type can be ONT (default). PB_HIFI/hifi support is planned."
     exit 1
 fi
+
+# Check read_type (temporary: only ONT is supported until hifi/nextpolish2 integration)
+if [[ "$read_type" != "ONT" ]]; then
+    >&2 echo "Error: Invalid read_type: $read_type."
+    >&2 echo "Currently, only 'ONT' is supported by this script."
+    >&2 echo "Support for 'hifi' reads (using NextPolish2) is planned."
+    exit 1
+fi
+
 assembly_abs=$(realpath "$assembly")
 
 # Check that the reads file exists.

--- a/scripts/plassembler.sh
+++ b/scripts/plassembler.sh
@@ -3,7 +3,8 @@
 # This script is a wrapper for running Plassembler in a single command.
 
 # Usage:
-#   plassembler.sh <read_fastq> <assembly_prefix> <threads>
+#   plassembler.sh <read_fastq> <assembly_prefix> <threads> [read_type]
+#   read_type can be ONT (default) or PB_HIFI
 
 # Requirements:
 #   Plassembler: https://github.com/gbouras13/plassembler
@@ -26,13 +27,21 @@
 set -e
 
 # Get arguments.
-reads=$1        # input reads FASTQ
-assembly=$2     # output assembly prefix (not including file extension)
-threads=$3      # thread count
+reads=$1            # input reads FASTQ
+assembly=$2         # output assembly prefix (not including file extension)
+threads=$3          # thread count
+read_type=${4:-ONT} # ONT or PB_HIFI, defaults to ONT if not provided
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" ]]; then
-    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads>"
+    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads> [read_type]"
+    >&2 echo "  read_type can be ONT (default) or PB_HIFI"
+    exit 1
+fi
+
+# Validate read_type
+if [[ "$read_type" != "ONT" && "$read_type" != "PB_HIFI" ]]; then
+    >&2 echo "Error: Invalid read_type: $read_type. Must be 'ONT' or 'PB_HIFI'."
     exit 1
 fi
 
@@ -43,7 +52,7 @@ if [[ ! -f "$reads" ]]; then
 fi
 
 # Ensure the requirements are met.
-for cmd in plassembler; do
+for cmd in plassembler seqtk; do
     if ! command -v "$cmd" &> /dev/null; then
         >&2 echo "Error: $cmd not found in PATH"
         exit 1
@@ -82,8 +91,14 @@ else
     gzipped_reads="$temp_dir/reads.fastq.gz"
 fi
 
+# Determine additional Plassembler options based on read_type
+plassembler_extra_opts=()
+if [[ "$read_type" == "PB_HIFI" ]]; then
+    plassembler_extra_opts+=(--pacbio_model pacbio-hifi)
+fi
+
 # Run Plassembler.
-plassembler long -d "$database" -l "$gzipped_reads" -o "$temp_dir"/out -t "$threads" --skip_qc
+plassembler long "${plassembler_extra_opts[@]}" -d "$database" -l "$gzipped_reads" -o "$temp_dir"/out -t "$threads" --skip_qc
 
 # Check if Plassembler ran successfully.
 if [[ ! -s "$temp_dir"/out/plassembler_plasmids.fasta ]]; then

--- a/scripts/raven.sh
+++ b/scripts/raven.sh
@@ -3,7 +3,8 @@
 # This script is a wrapper for running Raven in a single command.
 
 # Usage:
-#   raven.sh <read_fastq> <assembly_prefix> <threads>
+#   raven.sh <read_fastq> <assembly_prefix> <threads> [read_type]
+#   read_type is ignored, as raven does not have read-specific options
 
 # Requirements:
 #   Raven: https://github.com/lbcb-sci/raven
@@ -24,13 +25,15 @@
 set -e
 
 # Get arguments.
-reads=$1        # input reads FASTQ
-assembly=$2     # output assembly prefix (not including file extension)
-threads=$3      # thread count
+reads=$1            # input reads FASTQ
+assembly=$2         # output assembly prefix (not including file extension)
+threads=$3          # thread count
+read_type=${4:-ONT} # ignored, raven does not have read-specific options
 
 # Validate input parameters.
 if [[ -z "$reads" || -z "$assembly" || -z "$threads" ]]; then
-    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads>"
+    >&2 echo "Usage: $0 <read_fastq> <assembly_prefix> <threads> [read_type]"
+    >&2 echo "  read_type is ignored, as raven does not have read-specific options."
     exit 1
 fi
 


### PR DESCRIPTION
This commit introduces initial support for PacBio HiFi reads across various assembly tools. All relevant scripts now include an optional `read_type` parameter to specify the read type.

**Changes:**

* **LJA:** `read_type` is ignored.
* **Raven:** `read_type` is ignored.
* **Flye:** Switches between `--nano-hq` and `--pacbio-hifi`.
* **Canu:** Switches between `-nanopore` and `-pacbio-hifi`.
* **Plassembler:** Adds `--pacbio_model pacbio-hifi`.
* **Redbean:** Switches between `-x ont` and `-x ccs`.
* **metaMDBG:** Switches between `--in-ont` and `--in-hifi`.
* **Miniasm:** Depends on Minipolish PR [[#15](https://github.com/rrwick/Minipolish/pull/15)](https://github.com/rrwick/Minipolish/pull/15).
* **NECAT:** `ONT` only. `PB_HIFI` -> exit 1.
* **NextDenovo:** `ONT` only. `PB_HIFI` -> exit 1.