### PR TITLE
Add minipolish to dockerfile

### DIFF
--- a/pipelines/Dockerfile_by_Ryan_Wick/Dockerfile
+++ b/pipelines/Dockerfile_by_Ryan_Wick/Dockerfile
@@ -2,7 +2,7 @@ FROM mambaorg/micromamba:latest
 
 # Create an "autocycler" environment with long-read assemblers.
 RUN micromamba create -y -n autocycler python=3.12 -c conda-forge -c bioconda curl && \
-    for tool in canu flye lja metamdbg miniasm minimap2 minipolish3 minipolish necat nextdenovo nextpolish racon raven-assembler wtdbg; do \
+    for tool in canu flye lja metamdbg miniasm minimap2 minipolish necat nextdenovo nextpolish racon raven-assembler wtdbg; do \
         if micromamba install -y -n autocycler -c conda-forge -c bioconda "$tool"; then \
             printf " $tool" >> /tmp/installed_tools.txt; \
         else \

--- a/pipelines/Dockerfile_by_Ryan_Wick/Dockerfile
+++ b/pipelines/Dockerfile_by_Ryan_Wick/Dockerfile
@@ -2,7 +2,7 @@ FROM mambaorg/micromamba:latest
 
 # Create an "autocycler" environment with long-read assemblers.
 RUN micromamba create -y -n autocycler python=3.12 -c conda-forge -c bioconda curl && \
-    for tool in canu flye lja metamdbg miniasm minimap2 minipolish3 necat nextdenovo nextpolish racon raven-assembler wtdbg; do \
+    for tool in canu flye lja metamdbg miniasm minimap2 minipolish3 minipolish necat nextdenovo nextpolish racon raven-assembler wtdbg; do \
         if micromamba install -y -n autocycler -c conda-forge -c bioconda "$tool"; then \
             printf " $tool" >> /tmp/installed_tools.txt; \
         else \


### PR DESCRIPTION
In the cases where minipolish3 fails to install it breaks miniasm, while still claiming its installed ok.
I believe this should fix it for systems that fail to install minipolish3, although Im not sure what the effect would be on systems that end up installing both.