### PR TITLE
add slurm pipeline

### DIFF
--- a/pipelines/Slurm_Autocycler_Bash_script_by_Michael_Hall/README.md
+++ b/pipelines/Slurm_Autocycler_Bash_script_by_Michael_Hall/README.md
@@ -1,0 +1,67 @@
+# Automated Autocycler Slurm Bash script (by Michael Hall @mbhall88)
+
+This script is heavily inspired (copied) from Ryan's ([`full_autocycler.sh`](../Automated_Autocycler_Bash_script_by_Ryan_Wick/autocycler_full.sh)).
+
+It extends/changes the functionality in the following ways:
+- It allows optional read filtering up front with `filtlong`
+- It estimates genome size with [`lrge`](https://github.com/mbhall88/lrge). This reduces the memory and time requirements of this step drastically.
+- Each assembly job is submitted to the Slurm job scheduler using [`ssubmit`](https://github.com/mbhall88/ssubmit/). In the original script, each assembly job was run using `parallel` in batches based on the `jobs` value provided to the script. This script therefore allows running all assemblies concurrently (depending on job queues on your cluster). The script will wait for the jobs to complete, exiting if any of the jobs failed. This ultimately makes the full autocycler process faster - I am impatient...
+- There is a resume-after-assembly functionality. Sometimes I would find an assembly job might fail due to memory (or other) issues and then it is a bit annoying to manually run the remaining steps of the original script. This script has an option `-R` that allows you to manually complete that assembly job outside of this script and then rerun the autocycler process, skipping the filtering, subsampling, and assembly parts.
+
+## Dependencies
+
+All requirements are listed in the [`environment.yaml`](environment.yaml) file. You can create a conda environment with all the required software using:
+
+```bash
+conda env create -f environment.yaml
+```
+
+## Usage
+
+The only required argument is the input FASTQ file containing long reads for assembly. All other options are optional.
+
+**Basic usage example:**
+```bash
+./autocycler_slurm.sh -o output_directory -t 16 -l 1000 reads.fastq
+```
+
+```
+Usage: autocycler_slurm.sh <read_fastq> [options]
+This script performs long-read assembly using Autocycler on a Slurm cluster. 
+In particular, it submits each assembly job to the cluster scheduler, thus 
+enabling parallel execution of multiple assemblers and subsamples.
+
+Required:
+  <read_fastq>               Input FASTQ file for long-read assembly
+
+General options:
+  -o, --outdir <path>         Output directory [default: current directory]
+  -t, --threads <int>         Threads per assembly job [default: 8]
+  -r, --read-type <type>      Read type: ont_r9 | ont_r10 | pacbio_clr | pacbio_hifi [default: ont_r10]
+  -k, --keep-intermediate     Keep subsampled and filtered FASTQ files after assembly
+  -w, --overwrite             Delete output directory if it exists (use with caution!)
+  -T, --max-time <duration>   Slurm time limit per job [default: 8h]
+  -M, --max-mem <size>        Slurm memory per job [default: 32g]
+  -R, --resume-after-assembly Resume pipeline after assembly step (skip read filtering, subsampling, and assembly)
+
+Read filtering with filtlong:
+  -l, --min-length <int>      Filter out reads shorter than this length
+  -b, --target-bases <int>    Keep top reads until total base count is reached
+  -p, --keep-percent <float>  Keep best X%% of reads (e.g. 90)
+
+Help:
+  -h, --help                  Show this help message and exit
+```
+
+## Output
+
+The script creates the following outputs in the working directory:
+
+* **`subsampled_reads/`**: Contains the read subsets used for assembly. The FASTQ files are deleted after assembly to save space, but the directory (and its [YAML file](https://github.com/rrwick/Autocycler/wiki/Metrics#read-subsampling-metrics)) remains. You can use the `-k` option to keep these files.
+* **`filtered_reads/`**: Contains the filtered reads if read filtering was performed. You can use the `-k` option to keep these files, otherwise they are deleted after assembly.
+* **`assemblies/`**:
+  * Input assemblies for Autocycler in FASTA format
+  * GFA and log files for assemblers that produce them
+  * `slurm_logs/`: full stdout/stderr for each assembly slurm job
+* **`autocycler_out/`**: Output directory for Autocycler. Final results are saved as `consensus_assembly.gfa` and `consensus_assembly.fasta`.
+* **`autocycler.stderr`**: stderr output from all Autocycler steps.

--- a/pipelines/Slurm_Autocycler_Bash_script_by_Michael_Hall/autocycler_slurm.sh
+++ b/pipelines/Slurm_Autocycler_Bash_script_by_Michael_Hall/autocycler_slurm.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo_usage() {
+    echo "Usage: $0 <read_fastq> [options]"
+    echo
+    echo "Required:"
+    echo "  <read_fastq>               Input FASTQ file for long-read assembly"
+    echo
+    echo "General options:"
+    echo "  -o, --outdir <path>         Output directory [default: current directory]"
+    echo "  -t, --threads <int>         Threads per assembly job [default: 8]"
+    echo "  -r, --read-type <type>      Read type: ont_r9 | ont_r10 | pacbio_clr | pacbio_hifi [default: ont_r10]"
+    echo "  -k, --keep-intermediate     Keep subsampled and filtered FASTQ files after assembly"
+    echo "  -w, --overwrite             Delete output directory if it exists (use with caution!)"
+    echo "  -T, --max-time <duration>   Slurm time limit per job [default: 8h]"
+    echo "  -M, --max-mem <size>        Slurm memory per job [default: 32g]"
+    echo "  -R, --resume-after-assembly Resume pipeline after assembly step (skip read filtering, subsampling, and assembly)"
+    echo
+    echo "Read filtering with filtlong:"
+    echo "  -l, --min-length <int>      Filter out reads shorter than this length"
+    echo "  -b, --target-bases <int>    Keep top reads until total base count is reached"
+    echo "  -p, --keep-percent <float>  Keep best X%% of reads (e.g. 90)"
+    echo
+    echo "Help:"
+    echo "  -h, --help                  Show this help message and exit"
+}
+# ------------------------------
+# Parse args
+# ------------------------------
+reads=""
+threads="8"
+read_type="ont_r10"
+keep_intermediate=false
+max_time="8h"
+max_mem="32g"
+min_length=""
+target_bases=""
+keep_percent=""
+outdir="."
+overwrite=false
+resume_after_assembly=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -o | --outdir)
+        outdir="$2"
+        shift 2
+        ;;
+    -t | --threads)
+        threads="$2"
+        shift 2
+        ;;
+    -r | --read-type)
+        read_type="$2"
+        shift 2
+        ;;
+    -R | --resume-after-assembly)
+        resume_after_assembly=true
+        shift
+        ;;
+    -k | --keep-intermediate)
+        keep_intermediate=true
+        shift
+        ;;
+    -w | --overwrite)
+        overwrite=true
+        shift
+        ;;
+    -T | --max-time)
+        max_time="$2"
+        shift 2
+        ;;
+    -M | --max-mem)
+        max_mem="$2"
+        shift 2
+        ;;
+    -l | --min-length)
+        min_length="$2"
+        shift 2
+        ;;
+    -b | --target-bases)
+        target_bases="$2"
+        shift 2
+        ;;
+    -p | --keep-percent)
+        keep_percent="$2"
+        shift 2
+        ;;
+    -h | --help)
+        echo_usage
+        exit 0
+        ;;
+    -*)
+        echo "[ERROR] Unknown option: $1" >&2
+        echo "Use --help to see usage." >&2
+        exit 1
+        ;;
+    *)
+        if [[ -z "$reads" ]]; then
+            reads=$(realpath "$1")
+        else
+            echo "[ERROR] Unexpected positional argument: $1" >&2
+            echo "Use --help to see usage." >&2
+            exit 1
+        fi
+        shift
+        ;;
+    esac
+done
+
+if ((threads > 128)); then threads=128; fi
+case $read_type in
+ont_r9 | ont_r10 | pacbio_clr | pacbio_hifi) ;;
+*)
+    echo "[ERROR] read_type must be ont_r9, ont_r10, pacbio_clr or pacbio_hifi" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$overwrite" == true && "$resume_after_assembly" == true ]]; then
+    echo "[ERROR] Cannot use --overwrite and --resume-after-assembly together." >&2
+    echo "        Overwrite would delete assemblies/ directory needed for resume." >&2
+    exit 1
+fi
+
+if [[ -d "$outdir" && "$overwrite" == true ]]; then
+    echo "[WARN] Output directory '$outdir' exists and will be overwritten."
+    rm -rf "$outdir"
+fi
+
+mkdir -p "$outdir"
+echo "[INFO] Changing to output directory: $outdir"
+cd "$outdir"
+
+if [[ "$resume_after_assembly" == false ]]; then
+    # ------------------------------
+    # Optional: Filter reads with filtlong
+    # ------------------------------
+    if [[ -n "$min_length" || -n "$target_bases" || -n "$keep_percent" ]]; then
+        echo "[INFO] Filtering reads with filtlong..."
+        mkdir -p filtered
+
+        filtlong_cmd=(filtlong)
+        [[ -n "$min_length" ]] && filtlong_cmd+=(--min_length "$min_length")
+        [[ -n "$target_bases" ]] && filtlong_cmd+=(--target_bases "$target_bases")
+        [[ -n "$keep_percent" ]] && filtlong_cmd+=(--keep_percent "$keep_percent")
+
+        # Strip known FASTQ extensions and gz if present
+        basename_no_ext=$(basename "$reads" | sed -E 's/(\.fastq|\.fq)(\.gz)?$//')
+        reads_filtered="filtered/${basename_no_ext}_filtered.fastq"
+
+        "${filtlong_cmd[@]}" "$reads" >"$reads_filtered"
+        reads="$reads_filtered"
+
+        echo "[INFO] Filtered reads written to: $reads"
+    fi
+
+    # ------------------------------
+    # Estimate genome size
+    # ------------------------------
+    echo "[INFO] Estimating genome size..."
+    genome_size=$(lrge -t "$threads" "$reads" 2>autocycler.stderr)
+
+    # ------------------------------
+    # Subsample reads
+    # ------------------------------
+    echo "[INFO] Subsampling reads..."
+    autocycler subsample \
+        --reads "$reads" \
+        --out_dir subsampled_reads \
+        --genome_size "$genome_size" \
+        2>>autocycler.stderr
+
+    # ------------------------------
+    # Submit assembly jobs to Slurm
+    # ------------------------------
+    mkdir -p assemblies/slurm_logs
+    rm -f assemblies/job_ids.txt
+
+    echo "[INFO] Submitting assembly jobs..."
+    for assembler in raven myloasm miniasm flye metamdbg necat nextdenovo plassembler canu; do
+        for i in 01 02 03 04; do
+            sample="subsampled_reads/sample_${i}.fastq"
+            out_prefix="assemblies/${assembler}_${i}"
+            cmd="autocycler helper $assembler --reads $sample --out_prefix $out_prefix --threads $threads --genome_size $genome_size --read_type $read_type --min_depth_rel 0.1"
+            jobname="ac_${assembler}_${i}"
+
+            # Submit and extract job ID
+            jobid=$(ssubmit \
+                -t "$max_time" \
+                -m "$max_mem" \
+                -o "assemblies/slurm_logs/${jobname}.out" \
+                -e "assemblies/slurm_logs/${jobname}.err" \
+                "$jobname" \
+                "$cmd" -- -c "$threads" 2>&1 |
+                grep -oP 'Submitted batch job \K[0-9]+')
+
+            if [[ -n "$jobid" ]]; then
+                echo "[INFO] Submitted $jobname → JobID=$jobid"
+                echo "$jobid" >>assemblies/job_ids.txt
+            else
+                echo "[ERROR] Failed to get job ID for $jobname" >&2
+                exit 1
+            fi
+        done
+    done
+
+    # ------------------------------
+    # Wait for all jobs to complete, then check status
+    # ------------------------------
+    echo "[INFO] Waiting for assembly jobs to complete..."
+    sleep 10 # Give Slurm time to register jobs
+
+    start_time=$(date +%s)
+    mapfile -t job_ids <assemblies/job_ids.txt
+
+    while true; do
+        sleep 60
+
+        still_running=()
+        for jobid in "${job_ids[@]}"; do
+            if squeue -j "$jobid" 2>/dev/null | grep -q "$jobid"; then
+                still_running+=("$jobid")
+            fi
+        done
+
+        if ((${#still_running[@]} == 0)); then
+            echo "[INFO] All assembly jobs exited squeue. Verifying final status..."
+            break
+        fi
+
+        elapsed=$(($(date +%s) - start_time))
+        minutes=$((elapsed / 60))
+        seconds=$((elapsed % 60))
+        echo "[INFO] ${#still_running[@]} job(s) still running after ${minutes}m ${seconds}s: ${still_running[*]}"
+    done
+
+    # Check final state with sacct
+    fail_count=0
+    while read -r jobid; do
+        status=$(sacct -j "$jobid" --format=State --noheader | awk '{print $1}' | head -n 1)
+        if [[ "$status" != "COMPLETED" ]]; then
+            echo "[ERROR] Job $jobid failed with status: $status" >&2
+            ((fail_count++))
+        fi
+    done <assemblies/job_ids.txt
+
+    if ((fail_count > 0)); then
+        echo "[FATAL] $fail_count job(s) failed. Exiting." >&2
+        exit 1
+    fi
+
+    echo "[INFO] All assembly jobs completed successfully."
+else
+    echo "[INFO] Resuming pipeline after assembly."
+    if [[ ! -d assemblies ]]; then
+        echo "[ERROR] Cannot resume: assemblies/ directory not found." >&2
+        exit 1
+    fi
+fi # end resume_after_assembly check
+
+# ------------------------------
+# Adjust output weights
+# ------------------------------
+echo "[INFO] Adjusting assembly outputs..."
+shopt -s nullglob
+for f in assemblies/plassembler*.fasta; do
+    sed -i 's/circular=True/circular=True Autocycler_cluster_weight=3/' "$f"
+done
+for f in assemblies/canu*.fasta assemblies/flye*.fasta; do
+    sed -i 's/^>.*$/& Autocycler_consensus_weight=2/' "$f"
+done
+shopt -u nullglob
+
+# ------------------------------
+# Cleanup and continue pipeline
+# ------------------------------
+if [[ "$keep_intermediate" = false ]]; then
+    echo "[INFO] Removing intermediate reads..."
+    rm -rf subsampled_reads/*.fastq
+    rm -f filtered/*.fastq 2>/dev/null || true
+fi
+
+echo "[INFO] Running Autocycler compression, clustering, and resolution..."
+autocycler compress -i assemblies -a autocycler_out 2>>autocycler.stderr
+autocycler cluster -a autocycler_out 2>>autocycler.stderr
+
+for c in autocycler_out/clustering/qc_pass/cluster_*; do
+    autocycler trim -c "$c" 2>>autocycler.stderr
+    autocycler resolve -c "$c" 2>>autocycler.stderr
+done
+
+autocycler combine \
+    -a autocycler_out \
+    -i autocycler_out/clustering/qc_pass/cluster_*/5_final.gfa \
+    2>>autocycler.stderr
+
+echo "[INFO] Autocycler pipeline completed successfully."

--- a/pipelines/Slurm_Autocycler_Bash_script_by_Michael_Hall/environment.yaml
+++ b/pipelines/Slurm_Autocycler_Bash_script_by_Michael_Hall/environment.yaml
@@ -1,0 +1,23 @@
+name: autocycler
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - autocycler[version='>=0.5.0']
+  - miniasm[version='>=0.3']
+  - minimap2[version='>=2.28']
+  - wtdbg[version='>=2.5']
+  - metamdbg[version='>=1.0']
+  - minipolish[version='>=0.2.0']
+  - flye[version='>=2.9.6']
+  - plassembler[version='>=1.8.0']
+  - raven-assembler[version='>=1.8.3']
+  - racon[version='>=1.5.0']
+  - canu[version='>=2.3']
+  - necat[version='>=0.0.1_update20200803']
+  - myloasm
+  - nextdenovo[version='>=2.5.2']
+  - lrge
+  - filtlong[version='>=0.3.1']
+  - ssubmit
+  - nextpolish==1.4.1[build=*_4]


### PR DESCRIPTION
# Add Slurm-enabled Autocycler pipeline

This PR adds a new `autocycler_slurm.sh` script that enables scalable, Slurm-native execution of the full Autocycler pipeline. It supports concurrent assembly jobs, optional read filtering, genome size estimation, resume-after-assembly functionality, and safe output management. Inspired by Ryan's [`autocycler_full.sh`](https://github.com/rrwick/Autocycler/blob/main/pipelines/Automated_Autocycler_Bash_script_by_Ryan_Wick/autocycler_full.sh), but designed for HPC environments.

---

## Features

### Cluster-aware job submission
- Assembly jobs are submitted individually using [`ssubmit`](https://github.com/mbhall88/ssubmit), allowing parallelisation across HPC resources.
- Each job runs a single assembler/subsample combo with Slurm memory/time/thread control.

### Optional read filtering (with `filtlong`)
- Filter by:
  - Minimum read length
  - Target number of bases
  - Top X% of reads
- Runs once up front, creates `filtered/` directory.

### Genome size estimation
- Uses [`lrge`](https://github.com/mbhall88/lrge) (default).
- Accurate and lightweight genome size prediction before read subsampling.

### Resume mode
- `--resume-after-assembly` skips filtering, genome estimation, and assembly.
- Useful if a failed job is manually rerun and you want to resume clustering and resolution.

### Job monitoring & validation
- Displays job count/status updates while waiting.
- Uses `sacct` to verify that all Slurm jobs complete successfully.
- Fails early on job errors.

### Intermediate file control
- `--keep-intermediate` retains filtered + subsampled reads.
- `--overwrite` clears existing output directories (blocked if used with resume).
- `--outdir` sets working directory (defaults to current directory).

---

## Dependencies

Install with:

```bash
conda env create -f environment.yaml
conda activate autocycler
```
