### PR TITLE
Feature: Support LJA for genome size estimation in helper command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,10 @@ enum Commands {
         #[clap(long = "args", value_parser = clap::builder::NonEmptyStringValueParser::new(),
                num_args = 1.., action = clap::ArgAction::Append, allow_hyphen_values = true)]
         args: Vec<String>,
+
+        /// Assembler to use (for genome_size task)
+        #[clap(long = "assembler")]
+        assembler: Option<String>,
     },
 
     /// resolve repeats in the the unitig graph
@@ -349,9 +353,9 @@ fn main() {
             gfa2fasta::gfa2fasta(in_gfa, out_fasta);
         },
         Some(Commands::Helper { task, reads, out_prefix, genome_size, threads, dir, read_type,
-                                min_depth_abs, min_depth_rel, args }) => {
+                                min_depth_abs, min_depth_rel, args, assembler }) => {
             helper::helper(task, reads, out_prefix, genome_size, threads, dir, read_type,
-                           min_depth_abs, min_depth_rel, args);
+                           min_depth_abs, min_depth_rel, args, assembler);
         },
         Some(Commands::Resolve { cluster_dir, verbose }) => {
             resolve::resolve(cluster_dir, verbose);


### PR DESCRIPTION
## Description
This PR modifies the genome_size helper command to support **LJA** as an alternative assembler. Previously, the command hardcoded the use of Raven.

Motivation: LJA is significantly faster than Raven (though it may only be used for PacBio HiFi data?)

**Usage Example:**

```bash
# Default behavior (uses Raven)
autocycler helper genome_size --reads reads.fastq.gz

# Use LJA (faster for HiFi)
autocycler helper genome_size --reads reads.fastq.gz --assembler lja
```



## Performance

Benchmarking on a test dataset shows LJA is approximately **6x faster** in wall-clock time and **9x faster** in CPU time compared to Raven:

| Assembler | Real Time | User Time | Sys Time |
| :--- | :--- | :--- | :--- |
| **LJA** | 1m39.646s | 9m24.194s | 0m6.220s |
| **Raven** | 10m39.524s | 82m46.248s | 0m14.592s |

*Note: LJA support is currently limited to PacBio HiFi reads.*

## Changes
- **CLI**: Added `--assembler` argument to `autocycler helper genome_size`.
- **Logic**: Updated [src/helper.rs](file:///home/thomas/PycharmProjects/Autocycler/src/helper.rs) to handle the new argument.
    - If `--assembler lja` is passed, it calls [genome_size_lja](file:///home/thomas/PycharmProjects/Autocycler/src/helper.rs#412-432).
    - If `--assembler raven` (or nothing) is passed, it defaults to [genome_size_raven](file:///home/thomas/PycharmProjects/Autocycler/src/helper.rs#394-410).

