### PR TITLE
fix: avoid compiler overflow in table fields parsing

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -43,7 +43,7 @@ fn check_settings(autocycler_dir: &Option<PathBuf>, sigfigs: usize) {
 
 
 fn parse_fields(comma_delimited_fields: String) -> Vec<String> {
-    let fields = comma_delimited_fields.replace(" ", "").split(',')
+    let fields: Vec<String> = comma_delimited_fields.replace(" ", "").split(',')
                                        .map(|s| s.to_string()).collect();
     let mut valid_fields = HashSet::new();
     valid_fields.extend(SubsampleMetrics::get_field_names());
@@ -52,7 +52,7 @@ fn parse_fields(comma_delimited_fields: String) -> Vec<String> {
     valid_fields.extend(CombineMetrics::get_field_names());
     valid_fields.extend(UntrimmedClusterMetrics::get_field_names());
     valid_fields.extend(TrimmedClusterMetrics::get_field_names());
-    for field in &fields {
+    for field in fields.iter() {
         if !valid_fields.contains(field) {
             quit_with_error(&format!("{field} is not a valid field name"));
         }


### PR DESCRIPTION
This prevents a trait evaluation overflow ([E0275](https://doc.rust-lang.org/error_codes/E0275.html)) when compiling against older macOS SDKs, such as those used in Bioconda CI, where the compiler struggles to infer the `IntoIterator` implementation. See https://github.com/bioconda/bioconda-recipes/pull/62357

This has been patched on the Bioconda recipe to allow building v0.6.1. So when a release is made for this fix, we will just need to remove that patch.